### PR TITLE
Use optional argument in Product to properly initialise it

### DIFF
--- a/lib/tuple.gi
+++ b/lib/tuple.gi
@@ -81,7 +81,7 @@ InstallGlobalFunction(RandomGeneratingTuple,function(group, tuple, OurG, OurR)
   local i, k, t, product, c;
   while true do
     t:=List([1..2*OurG], x-> Random(group));
-    product:=Product(List([1..OurG], x->Comm(t[x], t[OurG+x])));
+    product:=Product(List([1..OurG], x->Comm(t[x], t[OurG+x])),One(group));
     if OurR=0 then
       if product=One(group) then
         return rec(tuple:=t, subgroupNumber:=1);
@@ -98,7 +98,6 @@ InstallGlobalFunction(RandomGeneratingTuple,function(group, tuple, OurG, OurR)
         if Size(Subgroup(group,t))= Size(group) then
           return rec(tuple:=t, subgroupNumber:=1);
         fi;
-        
       fi;
     fi;
   od;

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,5 +1,6 @@
 LoadPackage("mapclass");
 dir := DirectoriesPackageLibrary("mapclass", "tst");
-TestDirectory(dir, rec(exitGAP := true));
+TestDirectory(dir, rec(exitGAP := true,
+                       testOptions:=rec(compareFunction:="uptowhitespace")));
 
 FORCE_QUIT_GAP(1);


### PR DESCRIPTION
This uses optional `init` argument when calling `Product` as suggested by @fingolfin in #8, and fixes #8.

It also compares test output up to whitespaces, to prevent some invisible output produced when `OutputStyle:="silent"` is used.

I did not check other `Product` calls, because they may not be yet covered by tests.

